### PR TITLE
Newoptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,43 +3,43 @@ var statuses = require('statuses');
 
 
 module.exports = function (options) {
-  return function apiErrorHandler(err, req, res, next) {
-	  var stack = true;
-	  var opts = options || {};
-	  opts.noStackEnvs = opts.noStackEnvs || 'production';
-	  if(typeof(opts.noStackEnvs) != 'string')
-	   throw new Error('noStackEnvs option must be a string')
+	return function apiErrorHandler(err, req, res, next) {
+		var stack = true;
+		var opts = options || {};
+		opts.noStackEnvs = opts.hasOwnProperty('noStackEnvs')? opts.noStackEnvs: 'production'; // allow for empty string (stack for all)
+		if(typeof(opts.noStackEnvs) != 'string')
+			throw new Error('noStackEnvs option must be a string')
 
-	  opts.noStackEnvs.split(',').forEach(function(env) {
+		opts.noStackEnvs.split(',').forEach(function(env) {
 			if(env.trim() == process.env.NODE_ENV.toLowerCase())
 				stack = false;
-	  })
+		})
 
-    var status = err.status || err.statusCode || 500;
-    if (status < 400) status = 500;
-    res.statusCode = status;
+		var status = err.status || err.statusCode || 500;
+		if (status < 400) status = 500;
+		res.statusCode = status;
 
-    var body = {
-      status: status
-    };
+		var body = {
+			status: status
+		};
 
-    if (stack) body.stack = err.stack;
+		if (stack) body.stack = err.stack;
 
-    // internal server errors
-    if (status >= 500) {
-      console.error(err.stack);
-      body.message = statuses[status];
-      res.json(body);
-      return;
-    }
+		// internal server errors
+		if (status >= 500) {
+			console.error(err.stack);
+			body.message = statuses[status];
+			res.json(body);
+			return;
+		}
 
-    // client errors
-    body.message = err.message;
+		// client errors
+		body.message = err.message;
 
-    if (err.code) body.code = err.code;
-    if (err.name) body.name = err.name;
-    if (err.type) body.type = err.type;
+		if (err.code) body.code = err.code;
+		if (err.name) body.name = err.name;
+		if (err.type) body.type = err.type;
 
-    res.json(body);
-  }
+		res.json(body);
+	}
 }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,20 @@
 
 var statuses = require('statuses');
 
-var production = process.env.NODE_ENV === 'production';
 
-module.exports = function () {
+module.exports = function (options) {
   return function apiErrorHandler(err, req, res, next) {
+	  var stack = true;
+	  var opts = options || {};
+	  opts.noStackEnvs = opts.noStackEnvs || 'production';
+	  if(typeof(opts.noStackEnvs) != 'string')
+	   throw new Error('noStackEnvs option must be a string')
+
+	  opts.noStackEnvs.split(',').forEach(function(env) {
+			if(env.trim() == process.env.NODE_ENV.toLowerCase())
+				stack = false;
+	  })
+
     var status = err.status || err.statusCode || 500;
     if (status < 400) status = 500;
     res.statusCode = status;
@@ -13,9 +23,7 @@ module.exports = function () {
       status: status
     };
 
-    // show the stacktrace when not in production
-    // TODO: make this an option
-    if (!production) body.stack = err.stack;
+    if (stack) body.stack = err.stack;
 
     // internal server errors
     if (status >= 500) {


### PR DESCRIPTION
I thought this would be a nice way to handle the "stack" issue. I.e. you were already thinking about making the stack optional, but in reality, it's something they may or may not want for specific environments. If you let them pass that in, in a comma separated list, then they can shut down the stack where they want. By default it's always on, and off for production. I added an empty string option as well (always show the stack), as when I got to thinking about it, they might think that would do what you'd expect, always show the stack. 